### PR TITLE
fix platform and launcher false assignments + minor bug fixes and cleanup

### DIFF
--- a/Phoenix/Phoenix/Helpers/ImageUtils.swift
+++ b/Phoenix/Phoenix/Helpers/ImageUtils.swift
@@ -89,7 +89,7 @@ func resultIntoData(result: Result<[URL], Error>, completion: @escaping ((Data) 
         completion(data)
     }
     catch {
-        print("Failed to convert file to data: \(error.localizedDescription)")
+        logger.write("Failed to convert file to data: \(error.localizedDescription)")
     }
 }
 
@@ -104,7 +104,7 @@ func createCachedImagesDirectoryPath() -> (URL) {
     if !fileManager.fileExists(atPath: cachedImagesDirectoryPath.path) {
         do {
             try fileManager.createDirectory(at: cachedImagesDirectoryPath, withIntermediateDirectories: true, attributes: nil)
-            print("Created 'Phoenix/cachedImages' directory")
+            logger.write("Created 'Phoenix/cachedImages' directory")
         } catch {
             fatalError("Failed to create 'Phoenix/cachedImages' directory: \(error.localizedDescription)")
         }
@@ -146,9 +146,9 @@ func saveImageToFile(data: Data, gameID: UUID, type: String, completion: @escapi
         do {
             try data.write(to: destinationURL)
             completion(destinationURL.relativeString)
-            print("Saved image to: \(destinationURL.path)")
+            logger.write("Saved image to: \(destinationURL.path)")
         } catch {
-            print("Failed to save image: \(error.localizedDescription)")
+            logger.write("Failed to save image: \(error.localizedDescription)")
         }
     }
 }

--- a/Phoenix/Phoenix/Helpers/JsonUtils.swift
+++ b/Phoenix/Phoenix/Helpers/JsonUtils.swift
@@ -126,21 +126,15 @@ func detectCrossoverGames() async -> Set<String> {
     var crossoverGameNames: Set<String> = []
     
     // Find the <name>.app files and get name from them
-    do {
-        let crossoverFiles = try fileManager.contentsOfDirectory(
-            at: crossoverDirectory, includingPropertiesForKeys: nil
-        )
-        for crossoverFile in crossoverFiles {
-            let fileName = crossoverFile.lastPathComponent
+    if let enumerator = fileManager.enumerator(at: crossoverDirectory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
+        for case let fileURL as URL in enumerator {
+            let fileName = fileURL.lastPathComponent
             if fileName.hasSuffix(".app") {
                 let name = String(fileName.dropLast(4))
                 crossoverGameNames.insert(name)
                 logger.write("\(name) detected in CrossOver directory.")
             }
         }
-    }
-    catch {
-        logger.write("[ERROR]: Error adding to CrossOver games.")
     }
     return crossoverGameNames
 }

--- a/Phoenix/Phoenix/Models/Game.swift
+++ b/Phoenix/Phoenix/Models/Game.swift
@@ -251,17 +251,22 @@ func checkForPlatform(arr: [Game], plat: Platform) -> Bool {
 ///
 /// - Returns: An array of Games, aka. GamesList
 func loadGames() -> GamesList {
-    if Defaults[.steamDetection] {
-        Task {
-            await detectSteamGames()
+    Task {
+        var steamGameNames: Set<String> = []
+        var crossoverGameNames: Set<String> = []
+        
+        if Defaults[.steamDetection] {
+            steamGameNames = await detectSteamGames()
         }
-    }
-
-    if Defaults[.crossOverDetection] {
-        Task {
-            await detectCrossOverGamesAndWriteToJSON()
+        
+        if Defaults[.crossOverDetection] {
+            crossoverGameNames = await detectCrossoverGames()
         }
+        
+        await compareSteamAndCrossoverGames(steamGameNames: steamGameNames, crossoverGameNames: crossoverGameNames)
     }
+    
+    
     
     let res = loadGamesFromJSON()
     return res

--- a/Phoenix/Phoenix/PhoenixApp.swift
+++ b/Phoenix/Phoenix/PhoenixApp.swift
@@ -86,7 +86,6 @@ struct PhoenixApp: App {
             CommandGroup(replacing: CommandGroupPlacement.importExport) {
                 Button("Open Phoenix Data Folder") {
                     if let phoenixDirectory = getPhoenixDirectory() {
-                        print(phoenixDirectory)
                         NSWorkspace.shared.open(phoenixDirectory)
                         logger.write("[INFO]: Opened Application Support/Phoenix.")
                     }

--- a/Phoenix/Phoenix/Services/FetchSupabaseData.swift
+++ b/Phoenix/Phoenix/Services/FetchSupabaseData.swift
@@ -46,55 +46,30 @@ struct FetchSupabaseData {
         }
     }
     
-    func convertSupabaseGame(supabaseGame: SupabaseGame, gameID: UUID, completion: @escaping (Game) -> Void) {
+    func convertSupabaseGame(supabaseGame: SupabaseGame, game: Game, completion: @escaping (Game) -> Void) {
         var fetchedGame: Game
-        if let idx = games.firstIndex(where: { $0.id == gameID }) {
-            fetchedGame = .init(
-                id: gameID,
-                steamID: games[idx].steamID,
-                launcher: games[idx].launcher,
-                metadata: [
-                    "rating": games[idx].metadata["rating"] ?? "",
-                    "release_date": games[idx].metadata["release_date"] ?? "",
-                    "last_played": games[idx].metadata["last_played"] ?? "",
-                    "developer": games[idx].metadata["developer"] ?? "",
-                    "header_img": games[idx].metadata["header_img"] ?? "",
-                    "cover": games[idx].metadata["cover"] ?? "",
-                    "description": games[idx].metadata["description"] ?? "",
-                    "genre": games[idx].metadata["genre"] ?? "",
-                    "publisher": games[idx].metadata["publisher"] ?? "",
-                ],
-                icon: games[idx].icon,
-                name: games[idx].name,
-                platform: games[idx].platform,
-                status: games[idx].status,
-                recency: games[idx].recency,
-                isFavorite: games[idx].isFavorite
-            )
-        } else {
-            fetchedGame = .init(
-                id: gameID,
-                steamID: "",
-                launcher: "",
-                metadata: [
-                    "rating": "",
-                    "release_date": "",
-                    "last_played": "",
-                    "developer": "",
-                    "header_img": "",
-                    "cover": "",
-                    "description": "",
-                    "genre": "",
-                    "publisher": ""
-                ],
-                icon: "",
-                name: supabaseGame.name ?? "",
-                platform: .none,
-                status: .none,
-                recency: .never,
-                isFavorite: false
-            )
-        }
+        fetchedGame = .init(
+            id: game.id,
+            steamID: game.steamID,
+            launcher: game.launcher,
+            metadata: [
+                "rating": game.metadata["rating"] ?? "",
+                "release_date": game.metadata["release_date"] ?? "",
+                "last_played": game.metadata["last_played"] ?? "",
+                "developer": game.metadata["developer"] ?? "",
+                "header_img": game.metadata["header_img"] ?? "",
+                "cover": game.metadata["cover"] ?? "",
+                "description": game.metadata["description"] ?? "",
+                "genre": game.metadata["genre"] ?? "",
+                "publisher": game.metadata["publisher"] ?? "",
+            ],
+            icon: game.icon,
+            name: game.name,
+            platform: game.platform,
+            status: game.status,
+            recency: game.recency,
+            isFavorite: game.isFavorite
+        )
         
         fetchedGame.igdbID = String(supabaseGame.igdb_id)
         
@@ -121,19 +96,18 @@ struct FetchSupabaseData {
         
         if let steam_id = supabaseGame.steam_id {
             fetchedGame.steamID = String(steam_id)
-            if fetchedGame.launcher == "" {
+            if (fetchedGame.launcher == "" || fetchedGame.launcher.contains("%@")) && fetchedGame.platform == .steam {
                 fetchedGame.launcher = "open steam://run/\(steam_id)"
-            }
+            }   
         }
 
         if let imageURL = supabaseGame.header_img {
             if let url = URL(string: imageURL) {
                 URLSession.shared.dataTask(with: url) { headerData, response, error in
                     if let headerData = headerData {
-                        saveImageToFile(data: headerData, gameID: gameID, type: "header") { headerImage in
+                        saveImageToFile(data: headerData, gameID: fetchedGame.id, type: "header") { headerImage in
                             fetchedGame.metadata["header_img"] = headerImage
-                            print(headerImage)
-                            saveFetchedGame(gameID: gameID, fetchedGame: fetchedGame)
+                            saveFetchedGame(gameID: fetchedGame.id, fetchedGame: fetchedGame)
                         }
                     }
                 }.resume()

--- a/Phoenix/Phoenix/Services/FetchSupabaseData.swift
+++ b/Phoenix/Phoenix/Services/FetchSupabaseData.swift
@@ -120,6 +120,8 @@ struct FetchSupabaseData {
     func saveFetchedGame(gameID: UUID, fetchedGame: Game) {
         if let idx = games.firstIndex(where: { $0.id == gameID }) {
             games[idx] = fetchedGame
+        } else {
+            games.append(fetchedGame)
         }
         saveGames()
     }

--- a/Phoenix/Phoenix/Views/ChooseGameView.swift
+++ b/Phoenix/Phoenix/Views/ChooseGameView.swift
@@ -31,7 +31,7 @@ struct ChooseGameView: View {
                         }
                         VStack {
                             if let name = game.name {
-                                Text(name) // UNCENTER ThIS TEXT
+                                Text(name)
                                     .font(.system(size: 20))
                                     .fontWeight(.semibold)
                             }
@@ -68,7 +68,7 @@ struct ChooseGameView: View {
     
     func chooseGame(selectedGame: SupabaseGame) {
         done = true
-        FetchSupabaseData().convertSupabaseGame(supabaseGame: selectedGame, gameID: gameID) { result in
+        FetchSupabaseData().convertSupabaseGame(supabaseGame: selectedGame, game: Game(id: gameID)) { result in
             FetchSupabaseData().saveFetchedGame(gameID: gameID, fetchedGame: result)
         }
     }

--- a/Phoenix/Phoenix/Views/Components/Buttons/FolderImportButton.swift
+++ b/Phoenix/Phoenix/Views/Components/Buttons/FolderImportButton.swift
@@ -50,7 +50,6 @@ struct FolderImportButton: View {
                     folder = selectedFolder
                 }
             } catch {
-                // Handle the error, e.g., print an error message or take appropriate action.
                 logger.write("Error selecting folder: \(error)")
             }
         }

--- a/Phoenix/Phoenix/Views/Components/Buttons/HelpButton.swift
+++ b/Phoenix/Phoenix/Views/Components/Buttons/HelpButton.swift
@@ -38,7 +38,6 @@ struct HelpButton: View {
                             if let filepath = Bundle.main.path(forResource: "setup", ofType: "md") {
                                 do {
                                     markdown = try String(contentsOfFile: filepath)
-                                    print(markdown)
                                 } catch {
                                     logger.write("[ERROR]: Content of file couldn't be found.")
                                 }

--- a/Phoenix/Phoenix/Views/GameListView.swift
+++ b/Phoenix/Phoenix/Views/GameListView.swift
@@ -18,6 +18,7 @@ struct GameListView: View {
     
     @Default(.showSortByNumber) var showSortByNumber
     @Default(.showSidebarAddGameButton) var showSidebarAddGameButton
+    
     @Default(.accentColorUI) var accentColorUI
     @Default(.gradientUI) var gradientUI
     
@@ -64,7 +65,7 @@ struct GameListView: View {
                 case .name:
                     let gamesForName = games.filter {
                         $0.isHidden == false && ($0.name.localizedCaseInsensitiveContains(searchText) || searchText.isEmpty) && $0.isFavorite == false
-                    }
+                    }.sorted(by: { $0.name < $1.name })
                     if !gamesForName.isEmpty {
                         Section(header: Text("Name")) {
                             ForEach(gamesForName, id: \.id) { game in


### PR DESCRIPTION
fixes issue https://github.com/phoenixlauncher/phoenix/issues/91, when games from crossover were detected they would be given steam commands incorrectly. this commit fixes that and provides a rework of the function that converts games found in supabase to the Game object. 

also fixes a bug where the games wouldn't sort alphabetically when sorting by name, and cleanup of some print statements