### PR TITLE
Make "Play" and "Edit" button backgrounds clickable

### DIFF
--- a/Phoenix/Phoenix/Views/Components/Buttons/LargeToggleButton.swift
+++ b/Phoenix/Phoenix/Views/Components/Buttons/LargeToggleButton.swift
@@ -30,9 +30,10 @@ struct LargeToggleButton: View {
                     .foregroundColor(textColor)
                     .font(.system(size: 25))
             }
+            .frame(width: 175, height: 50)
+            .contentShape(RoundedRectangle(cornerRadius: 10))
         }
         .buttonStyle(.plain)
-        .frame(width: 175, height: 50)
         .background(
             Group {
                 if gradientUI {

--- a/Phoenix/Phoenix/Views/Components/Buttons/SmallToggleButton.swift
+++ b/Phoenix/Phoenix/Views/Components/Buttons/SmallToggleButton.swift
@@ -23,9 +23,10 @@ struct SmallToggleButton: View {
                 .fontWeight(.bold)
                 .foregroundColor(textColor)
                 .font(.system(size: 27))
+                .frame(width: 50, height: 50)
+                .contentShape(RoundedRectangle(cornerRadius: 10))
         }
         .buttonStyle(.plain)
-        .frame(width: 50, height: 50)
         .background(
             Group {
                 if gradientUI {


### PR DESCRIPTION
Previously the "Play" and "Edit" buttons in the detail view could only be clicked on the text/icons, this pr makes the whole button clickable