### PR TITLE
Add missing localizations for menu bar dropdowns

### DIFF
--- a/Phoenix/Phoenix.xcodeproj/xcshareddata/xcschemes/Phoenix.xcscheme
+++ b/Phoenix/Phoenix.xcodeproj/xcshareddata/xcschemes/Phoenix.xcscheme
@@ -56,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "de"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Phoenix/Phoenix.xcodeproj/xcshareddata/xcschemes/Phoenix.xcscheme
+++ b/Phoenix/Phoenix.xcodeproj/xcshareddata/xcschemes/Phoenix.xcscheme
@@ -56,7 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "sq"
+      language = "de"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Phoenix/Phoenix/App/ContentView.swift
+++ b/Phoenix/Phoenix/App/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
                                     appViewModel.isAddingGame.toggle()
                                 },
                                 label: {
-                                    Label("New Game", systemImage: "plus")
+                                    Label(String(localized: "file_AddGame"), systemImage: "plus")
                                 }
                             )
                         }

--- a/Phoenix/Phoenix/PhoenixApp.swift
+++ b/Phoenix/Phoenix/PhoenixApp.swift
@@ -70,21 +70,21 @@ struct PhoenixApp: App {
                 .environmentObject(appViewModel)
         }.commands {
             CommandGroup(before: CommandGroupPlacement.newItem) {
-                Button("Add Game") {
+                Button(String(localized: "file_AddGame")) {
                     appViewModel.isAddingGame.toggle()
                 }
                 .keyboardShortcut("n", modifiers: [.shift, .command])
-                Button("Edit Game") {
+                Button(String(localized: "file_EditGame")) {
                     appViewModel.isEditingGame.toggle()
                 }
                 .keyboardShortcut("e", modifiers: [.shift, .command])
-                Button("Play Game") {
+                Button(String(localized: "file_PlayGame")) {
                     appViewModel.isPlayingGame.toggle()
                 }
                 .keyboardShortcut("p", modifiers: [.shift, .command])
             }
             CommandGroup(replacing: CommandGroupPlacement.importExport) {
-                Button("Open Phoenix Data Folder") {
+                Button(String(localized: "file_PhoenixFolder")) {
                     if let phoenixDirectory = getPhoenixDirectory() {
                         NSWorkspace.shared.open(phoenixDirectory)
                         logger.write("[INFO]: Opened Application Support/Phoenix.")
@@ -93,19 +93,19 @@ struct PhoenixApp: App {
                 .keyboardShortcut("o", modifiers: [.command, .shift])
             }
             CommandGroup(replacing: CommandGroupPlacement.sidebar) {
-                Button("Sort Sidebar by Platform", action: {
+                Button(String(localized: "view_Platform"), action: {
                     sortBy = SortBy.platform
                 })
                 .keyboardShortcut("1", modifiers: .command)
-                Button("Sort Sidebar by Status", action: {
+                Button(String(localized: "view_Status"), action: {
                     sortBy = SortBy.status
                 })
                 .keyboardShortcut("2", modifiers: .command)
-                Button("Sort Sidebar by Name", action: {
+                Button(String(localized: "view_Name"), action: {
                     sortBy = SortBy.name
                 })
                 .keyboardShortcut("3", modifiers: .command)
-                Button("Sort Sidebar by Recency", action: {
+                Button(String(localized: "view_Recency"), action: {
                     sortBy = SortBy.recency
                 })
                 .keyboardShortcut("4", modifiers: .command)


### PR DESCRIPTION
I noticed while testing the German localization that we forgot to switch the menu bar items to use localized strings. This PR fixes buttons in the `File` and `View` menus.