### PR TITLE
Update for v0.1.7 build 25

### DIFF
--- a/Phoenix/Phoenix/Views/Components/TextBoxes/TextBox.swift
+++ b/Phoenix/Phoenix/Views/Components/TextBoxes/TextBox.swift
@@ -16,7 +16,7 @@ struct TextBox: View {
         HStack {
             Text(textBoxName)
                 .frame(width: 70, alignment: .leading)
-            PaneTextField(text: $input)
+            RoundTextEditor(text: $input)
                 .accessibility(label: Text("\(textBoxName) Input"))
         }
         .padding()

--- a/appcast.xml
+++ b/appcast.xml
@@ -4,11 +4,11 @@
         <title>Phoenix</title>
         <item>
             <title>0.1.7</title>
-            <pubDate>Mon, 08 Apr 2024 21:04:51 -0700</pubDate>
-            <sparkle:version>24</sparkle:version>
+            <pubDate>Tue, 09 Apr 2024 10:15:04 -0700</pubDate>
+            <sparkle:version>25</sparkle:version>
             <sparkle:shortVersionString>0.1.7</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/phoenixlauncher/phoenix/releases/download/v0.1.7-beta/Phoenix.dmg" length="7287227" type="application/octet-stream" sparkle:edSignature="auzp1cbEMRZRcbgRhaeodLgZYmfs+b6cB46J2UvkYcM//UPY4PN4DkPE6puoTkEieeE1F0uW7ltdFHf3FgajAA=="/>
+            <enclosure url="https://github.com/phoenixlauncher/phoenix/releases/download/v0.1.7-beta/Phoenix.dmg" length="7287046" type="application/octet-stream" sparkle:edSignature="89FAtYHM08RnekmV9ue25B2g2AAVZ6Oj4C6Q6K1I2QZcMj5oXdr+yb28ZWbi2W3Ja5R7tcqWR5zkRT90I/rZBQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
There was still a reference to `PaneTextField` in `TextBox.swift` so I replaced it with `RoundTextEditor` and it's working now

I also updated the appcast to use this new version